### PR TITLE
fix: preserve duplicate HTTP headers in responses

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -95,7 +95,7 @@ impl StreamingBody {
 pub struct RawResponseData {
     pub status: u16,
     pub url: String,
-    pub headers: HashMap<String, String>,
+    pub headers: Vec<(String, String)>,
     pub body: Vec<u8>,
     pub elapsed_ms: f64,
     pub history: Vec<RawResponseData>,
@@ -106,7 +106,7 @@ pub struct RawResponseData {
     pub request_url: String,
     pub request_headers: HashMap<String, String>,
     pub streaming_inner: Option<StreamingInner>,
-    pub streaming_headers: Option<HashMap<String, String>>,
+    pub streaming_headers: Option<Vec<(String, String)>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -199,11 +199,13 @@ impl Response {
         let (content_bytes, content_loaded, content_consumed, raw) =
             if let Some(streaming) = data.streaming_inner {
                 // Streaming: wrap in StreamingRawResponse
+                let streaming_hdrs_map: HashMap<String, String> =
+                    data.streaming_headers.unwrap_or_default().into_iter().collect();
                 let sb = Py::new(
                     py,
                     StreamingBody::new(
                         streaming,
-                        data.streaming_headers.unwrap_or_default(),
+                        streaming_hdrs_map,
                     ),
                 )?;
                 let streaming_cls = py

--- a/src/session.rs
+++ b/src/session.rs
@@ -693,7 +693,7 @@ impl Session {
 
     fn extract_response_headers(
         response: &reqwest::blocking::Response,
-    ) -> HashMap<String, String> {
+    ) -> Vec<(String, String)> {
         response
             .headers()
             .iter()


### PR DESCRIPTION
## Summary
- Change `extract_response_headers` return type from `HashMap<String, String>` to `Vec<(String, String)>` to preserve duplicate headers (e.g. multiple `Set-Cookie`)
- Update `RawResponseData.headers` and `streaming_headers` to use `Vec<(String, String)>`
- `email.Message` in `Response::from_raw` now receives all headers (its `__setitem__` appends, preserving duplicates for cookie extraction)

Closes #1

## Changes
- `src/session.rs:694-702` — `extract_response_headers` returns `Vec` instead of `HashMap`
- `src/response.rs:95-110` — `RawResponseData.headers` type changed to `Vec<(String, String)>`
- `src/response.rs:109` — `streaming_headers` type changed to `Option<Vec<(String, String)>>`
- `src/response.rs:202-206` — Convert `Vec` → `HashMap` at `StreamingBody` boundary

## Test results
- Group A: 289 passed, 43 skipped
- Group C: 38 passed