### PR TITLE
fix: improve SSL error detection with rustls downcast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 ] }
 serde_json = "1"
 base64 = "0.22"
+rustls = { version = "0.23", default-features = false }
 url = "2"
 indexmap = "2"
 percent-encoding = "2"


### PR DESCRIPTION
Closing — based on pre-#19 main (duplicated session.rs). Will re-implement on a single dev branch together with #6 and #9.