### PR TITLE
ci: fix release pipeline for TestPyPI/PyPI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -206,7 +206,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.publish_testpypi) }}
     needs: [linux, musllinux, windows, macos, sdist]
     permissions:
       id-token: write
@@ -214,26 +214,29 @@ jobs:
       attestations: write
     steps:
       - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List packages
+        run: ls -lh dist/
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: 'dist/*'
 
       - name: Publish to TestPyPI
         if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing --repository-url https://test.pypi.org/legacy/ wheels-*/*
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
 
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Summary
- Replace deprecated `maturin upload` with `pypa/gh-action-pypi-publish` (the PyPA standard)
- Consolidate wheel artifacts into single `dist/` using `merge-multiple: true`
- Wire up the `publish_testpypi` input toggle (was defined but never used)
- Fix attestation path to match new `dist/` layout

## Root Cause
`maturin upload` is deprecated since maturin 1.12.2. The glob expansion of `wheels-*/*` was consumed
by `--repository-url`, replacing the URL with a file path → `bad uri: ... is missing scheme`.

## Test plan
- [ ] PR CI: test + lint + wheel builds pass
- [ ] After merge: trigger `workflow_dispatch` with `publish_testpypi=true`
- [ ] Verify package appears on https://test.pypi.org/project/snekwest/
- [ ] Verify `pip install -i https://test.pypi.org/simple/ snekwest` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)