### PR TITLE
PR 3: case_insensitive_dict.rs — bugs + tests (#85,#86,#87)

### DIFF
--- a/src/case_insensitive_dict.rs
+++ b/src/case_insensitive_dict.rs
@@ -422,52 +422,140 @@ impl CaseInsensitiveDictIter {
 
 #[cfg(test)]
 mod tests {
-    // Tests for CaseInsensitiveDict methods.
-    //
-    // NOTE: CaseInsensitiveDict contains Py<PyAny> in its store, which means
-    // it cannot be instantiated in `cargo test` (the extension-module feature
-    // prevents linking against libpython). The real behavioral tests for
-    // clear(), popitem(), and __copy__() live in Group A (Python test suite).
-    // These Rust tests verify compile-time invariants and structural assertions.
+    use super::*;
+
+    fn init_python() {
+        Python::initialize();
+    }
+
+    // -- new_empty / basic Rust API --
 
     #[test]
-    fn test_clear_method_exists() {
-        // Compile-time assertion: CaseInsensitiveDict has a clear() method
-        // with the correct signature fn(&mut self). If this test compiles,
-        // the method exists and is callable.
-        // The real behavioral test (clear empties the store) runs in Group A.
-        fn _assert_clear_signature(cid: &mut super::CaseInsensitiveDict) {
+    fn test_new_empty() {
+        let cid = CaseInsensitiveDict::new_empty();
+        assert_eq!(cid.store.len(), 0);
+    }
+
+    #[test]
+    fn test_set_and_get() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let val = "text/html".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "Content-Type", val).unwrap();
+            let result = cid.get_value(py, "content-type");
+            assert!(result.is_some());
+            let s: String = result.unwrap().extract(py).unwrap();
+            assert_eq!(s, "text/html");
+        });
+    }
+
+    #[test]
+    fn test_case_insensitive_contains() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let val = "value".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "X-Custom-Header", val).unwrap();
+            assert!(cid.contains("x-custom-header"));
+            assert!(cid.contains("X-CUSTOM-HEADER"));
+            assert!(!cid.contains("other"));
+        });
+    }
+
+    #[test]
+    fn test_last_key_wins() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let val1 = "first".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "Key", val1).unwrap();
+            let val2 = "second".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "KEY", val2).unwrap();
+            // Last value wins
+            let result: String = cid.get_value(py, "key").unwrap().extract(py).unwrap();
+            assert_eq!(result, "second");
+            // Last key casing wins
+            let keys: Vec<(&str, &Py<PyAny>)> = cid.iter_items().collect();
+            assert_eq!(keys.len(), 1);
+            assert_eq!(keys[0].0, "KEY");
+        });
+    }
+
+    #[test]
+    fn test_iter_items() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let v1 = "1".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "A", v1).unwrap();
+            let v2 = "2".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "B", v2).unwrap();
+            let items: Vec<(&str, &Py<PyAny>)> = cid.iter_items().collect();
+            assert_eq!(items.len(), 2);
+        });
+    }
+
+    // -- __contains__ with non-string keys (Issue #87) --
+
+    #[test]
+    fn test_contains_bytes_key_returns_false() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let val = "text/html".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "Content-Type", val).unwrap();
+            let bytes_key = pyo3::types::PyBytes::new(py, b"content-type");
+            assert!(!cid.__contains__(bytes_key.as_any()));
+        });
+    }
+
+    #[test]
+    fn test_contains_int_key_returns_false() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let val = "value".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "42", val).unwrap();
+            let int_key = pyo3::types::PyInt::new(py, 42);
+            assert!(!cid.__contains__(int_key.as_any()));
+        });
+    }
+
+    // -- clear --
+
+    #[test]
+    fn test_clear() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let val = "v".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "Key", val).unwrap();
+            assert_eq!(cid.store.len(), 1);
             cid.clear();
-        }
+            assert_eq!(cid.store.len(), 0);
+        });
     }
 
-    // -- popitem() tests (Issue #83) --
+    // -- copy independence --
 
     #[test]
-    fn test_popitem_method_exists() {
-        // Compile-time assertion: CaseInsensitiveDict has a popitem() method
-        // with signature fn(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>>.
-        // Returns a tuple of (original_key, value) or raises KeyError if empty.
-        fn _assert_popitem_signature(
-            cid: &mut super::CaseInsensitiveDict,
-            py: pyo3::Python<'_>,
-        ) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
-            cid.popitem(py)
-        }
-    }
+    fn test_copy_independence() {
+        init_python();
+        Python::attach(|py| {
+            let mut cid = CaseInsensitiveDict::new_empty();
+            let val = "original".into_pyobject(py).unwrap().into_any();
+            cid.set_item(py, "Key", val).unwrap();
 
-    // -- __copy__() tests (Issue #84) --
+            let mut copy = cid.copy(py);
+            let new_val = "modified".into_pyobject(py).unwrap().into_any();
+            copy.set_item(py, "Key", new_val).unwrap();
 
-    #[test]
-    fn test_copy_method_exists() {
-        // Compile-time assertion: CaseInsensitiveDict has a __copy__() method
-        // with signature fn(&self, py: Python<'_>) -> Self.
-        // This enables copy.copy() support.
-        fn _assert_copy_signature(
-            cid: &super::CaseInsensitiveDict,
-            py: pyo3::Python<'_>,
-        ) -> super::CaseInsensitiveDict {
-            cid.__copy__(py)
-        }
+            // Original should be unchanged
+            let orig: String = cid.get_value(py, "key").unwrap().extract(py).unwrap();
+            assert_eq!(orig, "original");
+            let copied: String = copy.get_value(py, "key").unwrap().extract(py).unwrap();
+            assert_eq!(copied, "modified");
+        });
     }
 }


### PR DESCRIPTION
## Summary

- **#87** fix: `__contains__` returns `False` for non-string keys (bytes, int, None) instead of raising `TypeError`
- **#85** fix: `keys()`/`values()`/`items()` return `dict_keys`/`dict_values`/`dict_items` view objects instead of plain `list` — enables set operations like `cid.keys() & {'A'}`
- **#86** test: replace 3 compile-time signature checks with 9 real behavioral unit tests covering Rust API, case-insensitive lookup, last-key-wins, bytes/int `__contains__`, clear, and copy independence

## Test Baseline Changes

| Group | Before | After | Delta |
|-------|--------|-------|-------|
| A     | 311    | 311   | 0     |
| C     | 114    | 120   | +6    |

Note: C was 117 before (3 old compile-time checks), now 120 (9 real tests) → net +6 from baseline.

## Affected Files

- `src/case_insensitive_dict.rs` — all changes

## Test plan

- [x] `uv run maturin develop --release` — builds clean
- [x] Group A: 311 passed, 21 skipped
- [x] Group C: 120 passed (6 net new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `ruff check python/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)