### PR TITLE
#14: Cookie management → Rust via cookie_store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,8 @@ name = "_bindings"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "cookie",
+ "cookie_store",
  "indexmap",
  "percent-encoding",
  "pyo3",
@@ -148,12 +150,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -165,6 +206,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -553,6 +603,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +739,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -1110,6 +1194,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1402,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ url = "2"
 indexmap = "2"
 percent-encoding = "2"
 rustls = { version = "0.23", default-features = false }
+cookie_store = { version = "0.21", features = ["preserve_order"] }
+cookie = "0.18"

--- a/python/snekwest/sessions.py
+++ b/python/snekwest/sessions.py
@@ -160,7 +160,10 @@ class SessionRedirectMixin:
                     allow_redirects=False,
                     **adapter_kwargs,
                 )
-                extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
+                if hasattr(self, '_extract_cookies_to_session'):
+                    self._extract_cookies_to_session(prepared_request, resp.raw)
+                else:
+                    extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
                 url = self.get_redirect_target(resp)
                 yield resp
 


### PR DESCRIPTION
## Summary

- **Move Set-Cookie parsing to Rust**: `cookie_store` crate (v0.21) parses `Set-Cookie` headers from HTTP responses into a Rust-native `CookieStore` on `Session`
- **Move cookie matching to Rust**: Replace Python `get_cookie_header()` in `prepare_cookies_impl` with `cookie_matches_url()` — Rust-based domain/path/scheme/expiry matching
- **Two-layer architecture**: Rust `CookieStore` as authoritative store, Python `RequestsCookieJar` as thin compatibility wrapper synced via `sync_store_to_jar()`
- **16 new unit tests**: 10 for CookieStore operations, 6 for cookie_matches_url logic

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `cookie_store = "0.21"`, `cookie = "0.18"` |
| `src/session.rs` | `CookieStore` + `synced_cookies` fields, `parse_response_set_cookies`, `sync_store_to_jar`, `extract_cookies_from_raw`, `_extract_cookies_to_session` |
| `src/prepared_request.rs` | `cookie_matches_url()` function, rewrite `prepare_cookies_impl` to use Rust matching |
| `python/snekwest/sessions.py` | `resolve_redirects` uses `_extract_cookies_to_session` when available |
| `Cargo.lock` | Updated dependencies |

## Test plan

- [x] Group A: 311 passed, 21 skipped (baseline maintained)
- [x] Group C: 206 passed (was 193, +13 net new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `ruff check python/` clean
- [x] Cookie parsing from Set-Cookie headers works correctly
- [x] Domain matching (exact, suffix, supercookie) verified
- [x] Path matching verified
- [x] Secure flag / scheme check verified
- [x] Cookie expiry handling verified
- [x] Redirect cookie extraction uses Rust path

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)