### PR TITLE
Phase 1 completion: force_eager, encoding control, hooks (#119,#120,#121)

### DIFF
--- a/python/snekwest/hooks.py
+++ b/python/snekwest/hooks.py
@@ -6,11 +6,29 @@ This module provides the capabilities for the hooks system.
 
 Available hooks:
 
+``pre_request``:
+    Called after prepare_request() in Session.request(), before sending.
+    The hook receives the PreparedRequest as hook_data.
+
+``pre_send``:
+    Called in Session.send() just before the adapter sends the request.
+    The hook receives the PreparedRequest as hook_data.
+
 ``response``:
     The response generated from a Request.
+
+``on_redirect``:
+    Called during redirect resolution, after each intermediate response.
+    The hook receives the Response as hook_data.
+
+``on_error``:
+    Called when adapter.send() raises an exception.
+    The hook receives the exception as hook_data.
+    If the hook returns a non-None value, it is used as the response
+    instead of re-raising the exception.
 """
 
-HOOKS = ["response"]
+HOOKS = ["pre_request", "pre_send", "response", "on_redirect", "on_error"]
 
 
 def default_hooks():

--- a/src/response.rs
+++ b/src/response.rs
@@ -333,13 +333,26 @@ impl Response {
     }
 
     /// Internal: decode content bytes to text string.
-    fn decode_text(&self, py: Python<'_>) -> PyResult<String> {
+    ///
+    /// When `explicit_encoding` is `Some(enc)`, use that encoding with `"strict"`
+    /// error handling — invalid bytes raise `UnicodeDecodeError`.
+    /// When `None`, use the current behavior: encoding_inner → chardet → utf-8
+    /// with `"replace"` error handling.
+    fn decode_text(&self, py: Python<'_>, explicit_encoding: Option<&str>) -> PyResult<String> {
         let bytes = match &self.content_bytes {
             Some(b) if !b.is_empty() => b,
             _ => return Ok(String::new()),
         };
 
-        // Determine encoding
+        let py_bytes = PyBytes::new(py, bytes);
+
+        if let Some(enc) = explicit_encoding {
+            // Explicit encoding: strict error handling, no fallback
+            let s = py_bytes.call_method1("decode", (enc, "strict"))?;
+            return s.extract();
+        }
+
+        // Default path: encoding_inner → chardet → utf-8, "replace" errors
         let encoding: Option<String> = match &self.encoding_inner {
             Some(enc) => enc.extract(py).ok(),
             None => None,
@@ -351,7 +364,6 @@ impl Response {
         };
 
         // Decode
-        let py_bytes = PyBytes::new(py, bytes);
         match py_bytes.call_method1("decode", (&encoding, "replace")) {
             Ok(s) => s.extract(),
             Err(_) => {
@@ -695,7 +707,19 @@ impl Response {
     #[getter]
     fn text(&mut self, py: Python<'_>) -> PyResult<String> {
         self.ensure_content_loaded(py)?;
-        self.decode_text(py)
+        self.decode_text(py, None)
+    }
+
+    /// Decode response content with an explicit encoding.
+    ///
+    /// When `encoding` is provided, decode using that encoding with `"strict"`
+    /// error handling (raises `UnicodeDecodeError` on invalid bytes).
+    /// When `encoding` is `None`, identical behavior to `response.text`
+    /// (chardet guessing + `"replace"` error handling).
+    #[pyo3(signature = (encoding=None))]
+    fn text_with_encoding(&mut self, py: Python<'_>, encoding: Option<&str>) -> PyResult<String> {
+        self.ensure_content_loaded(py)?;
+        self.decode_text(py, encoding)
     }
 
     #[getter]
@@ -840,7 +864,7 @@ impl Response {
         }
 
         // Fall back to text-based parsing
-        let text = self.decode_text(py)?;
+        let text = self.decode_text(py, None)?;
         match json_mod.call_method("loads", (&text,), kwargs) {
             Ok(result) => Ok(result.unbind()),
             Err(e) => {
@@ -1498,6 +1522,130 @@ mod tests {
         };
         assert!(data.force_eager);
         assert!(data.streaming_inner.is_none());
+    }
+
+    // -- decode_text / text_with_encoding tests (#119) --
+
+    /// Helper: create a minimal Response with given content bytes and no encoding set.
+    fn make_response_with_content(py: Python<'_>, content: Vec<u8>) -> Response {
+        let mut resp = Response::py_new(py).unwrap();
+        resp.content_bytes = Some(Arc::new(content));
+        resp.body_state = ResponseBodyState::Consumed;
+        resp
+    }
+
+    #[test]
+    fn test_decode_text_no_explicit_encoding_uses_replace() {
+        // When no explicit encoding is given, invalid bytes should be replaced
+        // (not raise an error), matching the current response.text behavior.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            // 0xFF is not valid UTF-8 — with "replace" it becomes U+FFFD
+            let mut resp = make_response_with_content(py, vec![0x68, 0x65, 0x6C, 0xFF]);
+            // No encoding set → chardet will guess, but the fallback is utf-8 with replace
+            let result = resp.decode_text(py, None).unwrap();
+            // Should not raise, and should contain the valid prefix "hel"
+            assert!(result.starts_with("hel"));
+            // The invalid byte should be replaced, not cause an error
+            assert!(result.contains('\u{FFFD}') || result.len() >= 3);
+        });
+    }
+
+    #[test]
+    fn test_decode_text_explicit_utf8_valid() {
+        // Valid UTF-8 with explicit encoding should decode correctly.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let content = "hello world".as_bytes().to_vec();
+            let resp = make_response_with_content(py, content);
+            let result = resp.decode_text(py, Some("utf-8")).unwrap();
+            assert_eq!(result, "hello world");
+        });
+    }
+
+    #[test]
+    fn test_decode_text_explicit_utf8_invalid_raises() {
+        // Invalid UTF-8 with explicit encoding and "strict" should raise UnicodeDecodeError.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let content = vec![0x68, 0x65, 0x6C, 0xFF]; // "hel" + invalid byte
+            let resp = make_response_with_content(py, content);
+            let result = resp.decode_text(py, Some("utf-8"));
+            assert!(
+                result.is_err(),
+                "Expected UnicodeDecodeError for invalid UTF-8 with strict mode"
+            );
+        });
+    }
+
+    #[test]
+    fn test_decode_text_explicit_latin1() {
+        // Latin-1 can decode any byte sequence (0x00-0xFF).
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let content = vec![0x63, 0x61, 0x66, 0xE9]; // "caf" + 0xE9 = "café" in latin-1
+            let resp = make_response_with_content(py, content);
+            let result = resp.decode_text(py, Some("latin-1")).unwrap();
+            assert_eq!(result, "caf\u{00e9}"); // "café"
+        });
+    }
+
+    #[test]
+    fn test_decode_text_explicit_invalid_encoding_name_raises() {
+        // An invalid encoding name should raise LookupError.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let content = b"hello".to_vec();
+            let resp = make_response_with_content(py, content);
+            let result = resp.decode_text(py, Some("not-a-real-encoding"));
+            assert!(
+                result.is_err(),
+                "Expected LookupError for invalid encoding name"
+            );
+        });
+    }
+
+    #[test]
+    fn test_decode_text_empty_content_returns_empty_string() {
+        // Empty content should return empty string regardless of encoding.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let resp = make_response_with_content(py, vec![]);
+            let result = resp.decode_text(py, Some("utf-8")).unwrap();
+            assert_eq!(result, "");
+            let result_none = resp.decode_text(py, None).unwrap();
+            assert_eq!(result_none, "");
+        });
+    }
+
+    #[test]
+    fn test_decode_text_no_content_returns_empty_string() {
+        // No content_bytes at all should return empty string.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let mut resp = Response::py_new(py).unwrap();
+            resp.body_state = ResponseBodyState::Consumed;
+            // content_bytes is None
+            let result = resp.decode_text(py, Some("utf-8")).unwrap();
+            assert_eq!(result, "");
+            let result_none = resp.decode_text(py, None).unwrap();
+            assert_eq!(result_none, "");
+        });
+    }
+
+    #[test]
+    fn test_decode_text_explicit_ascii_with_non_ascii_raises() {
+        // ASCII encoding with bytes > 127 should raise with strict mode.
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| {
+            let content = vec![0x68, 0x65, 0x6C, 0x80]; // "hel" + 0x80
+            let resp = make_response_with_content(py, content);
+            let result = resp.decode_text(py, Some("ascii"));
+            assert!(
+                result.is_err(),
+                "Expected error for non-ASCII byte with ascii encoding in strict mode"
+            );
+        });
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -918,6 +918,7 @@ impl Session {
             request_headers: req_headers,
             streaming_inner: streaming_inner_opt,
             streaming_headers: streaming_hdrs,
+            force_eager: !streaming,
         })
     }
 


### PR DESCRIPTION
## Summary\n\nCompletes Phase 1 (Foundation) with the remaining 3 issues:\n\n- **#121 (P1-6)**: Add `force_eager: bool` field to `RawResponseData` — internal preparation for lazy-body default. Set in `do_request()` based on streaming decision. No observable behavior change.\n- **#119 (P1-4)**: Add `text_with_encoding(encoding=None)` method to `Response`. When encoding is provided, decodes with strict error handling (raises `UnicodeDecodeError`). When `None`, identical to `response.text` (backward compatible).\n- **#120 (P1-5)**: Extend hook system from 1 event (`response`) to 5 events: `pre_request`, `pre_send`, `response`, `on_redirect`, `on_error`. Fixes `merge_hooks()` to check all events, not just `\"response\"`.\n\n## Test Results\n\n| Check | Result |\n|-------|--------|\n| Group A | 311 passed, 21 skipped |\n| Group C | 222 passed (was 212 on main, +10) |\n| Clippy | Clean |\n| Fmt | Clean |\n| Ruff | Clean |\n\n## Test Count Changes\n\n- Group C: 212 → 222 (+10 new tests)\n  - +2 for `RawResponseData.force_eager` field (#121)\n  - +8 for `decode_text` with explicit encoding (#119)\n- Group A: unchanged (311/21)\n\nCloses #119\nCloses #120\nCloses #121\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"